### PR TITLE
Build using docker

### DIFF
--- a/.dockerginore
+++ b/.dockerginore
@@ -1,0 +1,3 @@
+.git
+Dockerfile
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y make git python3 python3-pip cmake libusb-1.0.0-dev && \
+    apt-get autoclean -y && \
+	ln -s /usr/bin/python3 /usr/bin/python
+
+WORKDIR /srv
+
+COPY ./ ./
+
+RUN cp config_T5-4.7 config && \
+    make
+


### PR DESCRIPTION
I ran into #6 and therefore needed a way to make the build consistent, therefore I added a simple Dockerfile that allows for consistent builds without polluting the system with extra packages.

The image is not meant to be slim, the resulting image is 17.1GB in size, which is far from optimal, but the objective was just to get the firmware bins in a consistent manner that could run on any computer without having compatibility issues.