### PR TITLE
Fixed a relative path refernce in a cmake file.

### DIFF
--- a/extmod/display/lcd/src/micropython.cmake
+++ b/extmod/display/lcd/src/micropython.cmake
@@ -1,3 +1,4 @@
-set(LCD_DIR ${CMAKE_BINARY_DIR}/../lcd_binding_micropython)
+# set(LCD_DIR ${CMAKE_BINARY_DIR}/../lcd_binding_micropython)
+set(LCD_DIR ${CMAKE_BINARY_DIR}/../../../tmp/dl/lcd_binding_micropython)
 
 include(${LCD_DIR}/lcd/micropython.cmake)


### PR DESCRIPTION
I was unable to compile in my machine without this change. Hopefully this is a sensible change to offer upstream.